### PR TITLE
fix(service): remove log.Fatalln from OpenStack error paths

### DIFF
--- a/internal/service/compute.go
+++ b/internal/service/compute.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -68,10 +67,7 @@ func (cs *computeService) CreateCompute(ctx context.Context, authToken string, r
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 		cs.logger.WithFields(logrus.Fields{
 			"status_code": resp.StatusCode,
 			"error_msg":   resp.Status,

--- a/internal/service/loadbalancer.go
+++ b/internal/service/loadbalancer.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -274,10 +273,7 @@ func (lbc *loadbalancerService) CreatePool(ctx context.Context, authToken string
 			"statusCode": resp.StatusCode,
 			"status":     resp.Status,
 		}).Error("failed to create pool")
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 
 		return resource.CreatePoolResponse{}, fmt.Errorf("failed to create pool, status code: %v, error msg: %v", resp.StatusCode, string(b))
 	}
@@ -327,10 +323,7 @@ func (lbc *loadbalancerService) CreateMember(ctx context.Context, authToken, poo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 		// lbc.logger.Errorf("failed to create member, status code: %v, error msg: %v", resp.StatusCode, string(b))
 		lbc.logger.WithFields(logrus.Fields{
 			"poolID":     poolID,
@@ -463,10 +456,7 @@ func (lbc *loadbalancerService) CreateHealthHTTPMonitor(ctx context.Context, aut
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 
 		lbc.logger.WithFields(logrus.Fields{
 			"poolID":     req.HealthMonitor.PoolID,
@@ -520,10 +510,7 @@ func (lbc *loadbalancerService) CreateHealthTCPMonitor(ctx context.Context, auth
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 
 		lbc.logger.WithFields(logrus.Fields{
 			"poolID":     req.HealthMonitor.PoolID,

--- a/internal/service/network.go
+++ b/internal/service/network.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httputil"
 	"strings"
@@ -232,10 +231,7 @@ func (ns *networkService) CreateSecurityGroupRuleForIP(ctx context.Context, auth
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 
 		ns.logger.WithFields(logrus.Fields{
 			"status_code": resp.StatusCode,
@@ -271,10 +267,7 @@ func (ns *networkService) CreateSecurityGroupRuleForSG(ctx context.Context, auth
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 
 		ns.logger.WithFields(logrus.Fields{
 			"status_code": resp.StatusCode,
@@ -315,10 +308,7 @@ func (ns *networkService) CreateFloatingIP(ctx context.Context, authToken string
 			"status_code": resp.StatusCode,
 			"error_msg":   resp.Status,
 		}).Error("failed to create floating ip")
-		b, err := httputil.DumpResponse(resp, true)
-		if err != nil {
-			log.Fatalln(err)
-		}
+		b, _ := httputil.DumpResponse(resp, true)
 		return resource.CreateFloatingIPResponse{}, fmt.Errorf("failed to create floating ip, status code: %v, error msg: %v, full msg: %v", resp.StatusCode, resp.Status, string(b))
 	}
 


### PR DESCRIPTION
## Problem
8 OpenStack service error paths called `log.Fatalln(err)`. `log.Fatalln` calls `os.Exit(1)`, so if dumping a non-2xx response failed mid-read (e.g. connection reset), the **entire API process crashed**, killing all in-flight cluster operations.

## Fix
Replaced `b, err := httputil.DumpResponse(...)` + `if err != nil { log.Fatalln }` with `b, _ := httputil.DumpResponse(...)`. Behavior preserved: the error and body are still returned via `fmt.Errorf`; if the dump fails the body is empty, but the process stays alive. Removed the now-unused `"log"` imports.

**Affected:** `compute.CreateCompute`; `network.CreateSecurityGroupRuleForIP/ForSG/CreateFloatingIP`; `loadbalancer.CreatePool/CreateMember/CreateHealthHTTPMonitor/CreateHealthTCPMonitor`

## Testing
- `go build ./...` and `go vet ./...` pass
- Manually verified the failure path: with a simulated response
  body-read error (httptest), the old code called `os.Exit(1)` and
  terminated the process, while the patched code returns a normal
  error instead. (Throwaway test, not committed — repo has no test
  suite yet)