### PR TITLE
fix: log cluster delete retries as warnings until the job fails permanently

### DIFF
--- a/cmd/worker/backoff_test.go
+++ b/cmd/worker/backoff_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/vmindtech/vke/internal/service"
 )
 
 func TestRetryBackoff(t *testing.T) {
@@ -24,4 +27,15 @@ func TestRetryBackoff(t *testing.T) {
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, retryBackoff(tt.attempts), "attempts=%d", tt.attempts)
 	}
+}
+
+func TestIsDeleteJobPermanent(t *testing.T) {
+	t.Parallel()
+
+	transient := fmt.Errorf("octavia 409")
+	assert.False(t, isDeleteJobPermanent(transient, 1, 10))
+	assert.False(t, isDeleteJobPermanent(transient, 9, 10))
+	assert.True(t, isDeleteJobPermanent(transient, 10, 10))
+	assert.True(t, isDeleteJobPermanent(service.ErrDestroyClusterPermanent, 1, 10))
+	assert.True(t, isDeleteJobPermanent(fmt.Errorf("%w: missing credentials", service.ErrDestroyClusterPermanent), 2, 10))
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -363,7 +363,7 @@ func handleDelivery(
 				"nextRunAt": next,
 				"retryable": true,
 				"outcome":   "retrying",
-			}).Warn("cluster delete job failed; will retry")
+			}).Info("cluster delete job failed; will retry")
 			return true, backoff, err
 		}
 		_ = repo.Jobs().MarkJobSucceeded(ctx, job.JobUUID)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/vmindtech/vke/config"
 	"github.com/vmindtech/vke/internal/dto/request"
+	"github.com/vmindtech/vke/internal/model"
 	"github.com/vmindtech/vke/internal/repository"
 	"github.com/vmindtech/vke/internal/service"
 	"github.com/vmindtech/vke/pkg/constants"
@@ -344,15 +345,25 @@ func handleDelivery(
 		// RunDestroyCluster: delete_state machine until COMPLETED; idempotent for queue retries.
 		if err := clusterSvc.RunDestroyCluster(ctx, authToken, deletePayload.ClusterID); err != nil {
 			attempts := job.Attempts + 1
-			backoff := retryBackoff(attempts)
-			next := time.Now().Add(backoff)
-			if attempts >= job.MaxAttempts {
-				_ = repo.Jobs().MarkJobFailed(ctx, job.JobUUID, err.Error(), next, attempts)
-				entry.WithError(err).WithField("attempts", attempts).Error("cluster delete job failed permanently")
+			if isDeleteJobPermanent(err, attempts, job.MaxAttempts) {
+				_ = repo.Jobs().MarkJobFailed(ctx, job.JobUUID, err.Error(), time.Now(), attempts)
+				persistDeleteJobFailure(ctx, entry, repo, clusterLogID)
+				entry.WithError(err).WithFields(logrus.Fields{
+					"attempts":  attempts,
+					"retryable": false,
+					"outcome":   "failed_permanently",
+				}).Error("cluster delete job failed permanently")
 				return false, 0, err
 			}
+			backoff := retryBackoff(attempts)
+			next := time.Now().Add(backoff)
 			_ = repo.Jobs().MarkJobFailed(ctx, job.JobUUID, err.Error(), next, attempts)
-			entry.WithError(err).WithFields(logrus.Fields{"attempts": attempts, "nextRunAt": next}).Warn("cluster delete job failed; will retry")
+			entry.WithError(err).WithFields(logrus.Fields{
+				"attempts":  attempts,
+				"nextRunAt": next,
+				"retryable": true,
+				"outcome":   "retrying",
+			}).Warn("cluster delete job failed; will retry")
 			return true, backoff, err
 		}
 		_ = repo.Jobs().MarkJobSucceeded(ctx, job.JobUUID)
@@ -369,6 +380,24 @@ func handleDelivery(
 // and used as the RabbitMQ retry-queue TTL so the two stay consistent.
 func retryBackoff(attempts int) time.Duration {
 	return time.Duration(attempts*attempts) * 10 * time.Second
+}
+
+func isDeleteJobPermanent(err error, attempts, maxAttempts int) bool {
+	return errors.Is(err, service.ErrDestroyClusterPermanent) || attempts >= maxAttempts
+}
+
+func persistDeleteJobFailure(ctx context.Context, logger *logrus.Entry, repo repository.IRepository, clusterID string) {
+	if strings.TrimSpace(clusterID) == "" {
+		return
+	}
+	recErr := repo.Error().CreateError(ctx, &model.Error{
+		ClusterUUID:  clusterID,
+		ErrorMessage: constants.GetErrorMessage(constants.ErrClusterDeleteFailed, "cluster_deletion", clusterID),
+		CreatedAt:    time.Now(),
+	})
+	if recErr != nil {
+		logger.WithError(recErr).Warn("failed to persist cluster delete failure")
+	}
 }
 
 // deleteJobAuthToken returns the fallback OpenStack token from a delete payload, decrypting

--- a/internal/repository/mocks/repository_mock.go
+++ b/internal/repository/mocks/repository_mock.go
@@ -209,6 +209,21 @@ func (mr *MockIClusterRepositoryMockRecorder) ClearLoadbalancerUUIDIfMatches(ctx
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearLoadbalancerUUIDIfMatches", reflect.TypeOf((*MockIClusterRepository)(nil).ClearLoadbalancerUUIDIfMatches), ctx, clusterUUID, loadBalancerUUID)
 }
 
+// ClusterNameExists mocks base method.
+func (m *MockIClusterRepository) ClusterNameExists(ctx context.Context, projectID, clusterName string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClusterNameExists", ctx, projectID, clusterName)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClusterNameExists indicates an expected call of ClusterNameExists.
+func (mr *MockIClusterRepositoryMockRecorder) ClusterNameExists(ctx, projectID, clusterName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterNameExists", reflect.TypeOf((*MockIClusterRepository)(nil).ClusterNameExists), ctx, projectID, clusterName)
+}
+
 // CreateCluster mocks base method.
 func (m *MockIClusterRepository) CreateCluster(ctx context.Context, cluster *model.Cluster) error {
 	m.ctrl.T.Helper()

--- a/internal/service/cloudflare.go
+++ b/internal/service/cloudflare.go
@@ -149,7 +149,7 @@ func (cf *cloudflareService) DeleteDNSRecordFromCloudflare(ctx context.Context, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		cf.logger.WithField("dnsRecordID", dnsRecordID).Errorf("failed to delete dns record, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
+		logHTTPStatusFailure(cf.logger.WithField("dnsRecordID", dnsRecordID), resp.StatusCode, resp.Status, "failed to delete dns record")
 		return fmt.Errorf("failed to delete dns record, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 
@@ -174,7 +174,7 @@ func (cf *cloudflareService) DeleteDNSRecord(ctx context.Context, recordID strin
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		cf.logger.WithField("recordID", recordID).Errorf("failed to delete dns record, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
+		logHTTPStatusFailure(cf.logger.WithField("recordID", recordID), resp.StatusCode, resp.Status, "failed to delete dns record")
 		return fmt.Errorf("failed to delete dns record, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 

--- a/internal/service/cluster.go
+++ b/internal/service/cluster.go
@@ -2832,7 +2832,7 @@ func (c *clusterService) verifyLoadBalancerDeletedThreePasses(ctx context.Contex
 				"clusterUUID":      clusterUUID,
 				"loadbalancerUUID": lbID,
 				"verifyPass":       i,
-			}).Warn("load balancer still present on post-delete verify; re-issuing Octavia delete and wait")
+			}).Info("load balancer still present on post-delete verify; re-issuing Octavia delete and wait")
 			relbErr := c.loadbalancerService.DeleteLoadbalancer(ctx, token, lbID)
 			if relbErr != nil && !strings.Contains(strings.ToLower(relbErr.Error()), "404") {
 				return fmt.Errorf("post-delete verify %d/3: re-delete cluster=%s lb=%s: %w", i, clusterUUID, lbID, relbErr)
@@ -3300,7 +3300,7 @@ func (c *clusterService) deleteSecurityGroups(ctx context.Context, authToken str
 		c.logger.WithFields(logrus.Fields{
 			"clusterUUID": cluster.ClusterUUID,
 			"attempt":     attempt,
-		}).Warn("retrying security group deletion")
+		}).Info("retrying security group deletion")
 
 		time.Sleep(time.Duration(attempt) * 5 * time.Second)
 	}
@@ -3340,7 +3340,7 @@ func (c *clusterService) deleteApplicationCredentials(ctx context.Context, ident
 		}
 		c.logger.WithError(err).WithFields(logrus.Fields{
 			"clusterUUID": cluster.ClusterUUID,
-		}).Warn("caller token did not delete application credential; retrying with cluster identity token")
+		}).Info("caller token did not delete application credential; retrying with cluster identity token")
 	}
 
 	if delErr := tryDelete(strings.Clone(identityToken)); delErr != nil {

--- a/internal/service/cluster.go
+++ b/internal/service/cluster.go
@@ -35,6 +35,9 @@ var ErrStaleCreateClusterJob = errors.New("create job obsolete: cluster deleted 
 // ErrClusterNameAlreadyExists is returned when a non-deleted cluster in the same project has the requested name.
 var ErrClusterNameAlreadyExists = repository.ErrClusterNameAlreadyExists
 
+// ErrDestroyClusterPermanent is a non-retryable CLUSTER_DELETE failure (missing credentials, bad config).
+var ErrDestroyClusterPermanent = errors.New("cluster deletion cannot be retried")
+
 // Octavia LB child resources (resources.resource_type), for idempotent create + pool member tracking.
 const (
 	resLBListenerAPI = "lb_listener_api"
@@ -2552,8 +2555,7 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 	for {
 		cluster, err := c.repository.Cluster().GetClusterByUUID(ctx, clusterID)
 		if err != nil {
-			c.logger.WithError(err).WithField("clusterUUID", clusterID).Error("failed to get cluster")
-			c.logClusterErrorWithDetails(ctx, clusterID, constants.ErrDatabaseQueryFailed, "cluster_deletion", err.Error())
+			logRetryableFailure(c.logger.WithField("clusterUUID", clusterID), err, "failed to get cluster")
 			return err
 		}
 
@@ -2580,34 +2582,28 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 		} else if strings.TrimSpace(cluster.ApplicationCredentialID) != "" && strings.TrimSpace(cluster.ApplicationCredentialSecretEnc) != "" {
 			encKey := config.GlobalConfig.GetEncryptionConfig().Key
 			if encKey == "" {
-				return fmt.Errorf("VKE_ENCRYPTION_KEY must be set")
+				return fmt.Errorf("%w: VKE_ENCRYPTION_KEY must be set", ErrDestroyClusterPermanent)
 			}
 			derived := sha256Sum(encKey)
 			appSecret, derr := utils.DecryptAESGCM(derived, cluster.ApplicationCredentialSecretEnc)
 			if derr != nil {
-				c.logger.WithError(derr).WithField("clusterUUID", clusterID).Error("failed to decrypt application credential secret")
-				return derr
+				return fmt.Errorf("%w: decrypt application credential: %w", ErrDestroyClusterPermanent, derr)
 			}
 			token, err = c.identityService.AuthenticateWithApplicationCredential(ctx, cluster.ApplicationCredentialID, appSecret)
 			if err != nil {
-				c.logger.WithError(err).WithField("clusterUUID", clusterID).Error("failed to authenticate with application credential for cluster deletion")
-				c.logClusterErrorSimple(ctx, clusterID, constants.ErrAuthTokenCheckFailed, "cluster_deletion")
+				logRetryableFailure(c.logger.WithField("clusterUUID", clusterID), err, "failed to authenticate with application credential for cluster deletion")
 				return err
 			}
 		} else {
 			token = strings.Clone(authToken)
 			if strings.TrimSpace(token) == "" {
-				c.logger.WithField("clusterUUID", clusterID).Error("cluster has no application credential and no auth token for deletion")
-				return fmt.Errorf("missing credentials for cluster destruction")
+				return fmt.Errorf("%w: missing credentials for cluster destruction", ErrDestroyClusterPermanent)
 			}
 		}
 
 		if token != "" {
 			if err := c.identityService.CheckAuthToken(ctx, token, cluster.ClusterProjectUUID); err != nil {
-				c.logger.WithError(err).WithFields(logrus.Fields{
-					"clusterUUID": clusterID,
-				}).Error("failed to check auth token")
-				c.logClusterErrorSimple(ctx, clusterID, constants.ErrAuthTokenCheckFailed, "cluster_deletion")
+				logRetryableFailure(c.logger.WithField("clusterUUID", clusterID), err, "failed to check auth token")
 				return err
 			}
 		}
@@ -2619,8 +2615,7 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 				DeleteState:       constants.DeleteStateInitial,
 			}, clusterID)
 			if err != nil {
-				c.logger.WithError(err).WithField("clusterUUID", clusterID).Error("failed to update cluster status")
-				c.logClusterErrorWithDetails(ctx, clusterID, constants.ErrDatabaseQueryFailed, "cluster_deletion", err.Error())
+				logRetryableFailure(c.logger.WithField("clusterUUID", clusterID), err, "failed to update cluster status")
 				return err
 			}
 			continue
@@ -2651,7 +2646,6 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 		case constants.DeleteStateInitial:
 			stepErr = c.deleteDNSRecord(ctx, cluster)
 			if stepErr != nil {
-				c.logClusterErrorFiltered(ctx, cluster.ClusterUUID, constants.ErrDNSRecordDeleteFailed, "cluster_deletion", stepErr)
 				return stepErr
 			}
 			cluster.DeleteState = constants.DeleteStateLoadBalancer
@@ -2662,7 +2656,6 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 		case constants.DeleteStateLoadBalancer:
 			stepErr = c.deleteFloatingIP(ctx, token, cluster)
 			if stepErr != nil {
-				c.logClusterErrorFiltered(ctx, cluster.ClusterUUID, constants.ErrFloatingIPDeleteFailed, "cluster_deletion", stepErr)
 				return stepErr
 			}
 			cluster.DeleteState = constants.DeleteStateDNS
@@ -2673,7 +2666,6 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 		case constants.DeleteStateDNS:
 			stepErr = c.deleteNodeGroups(ctx, token, cluster)
 			if stepErr != nil {
-				c.logClusterErrorFiltered(ctx, cluster.ClusterUUID, constants.ErrNodeGroupDeleteFailed, "cluster_deletion", stepErr)
 				return stepErr
 			}
 			cluster.DeleteState = constants.DeleteStateFloatingIP
@@ -2684,7 +2676,6 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 		case constants.DeleteStateFloatingIP:
 			stepErr = c.deleteSecurityGroups(ctx, token, cluster)
 			if stepErr != nil {
-				c.logClusterErrorFiltered(ctx, cluster.ClusterUUID, constants.ErrSecurityGroupDeleteFailed, "cluster_deletion", stepErr)
 				return stepErr
 			}
 			cluster.DeleteState = constants.DeleteStateNodes
@@ -2709,7 +2700,6 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 		case constants.DeleteStateSecurityGroups:
 			stepErr = c.deleteApplicationCredentials(ctx, token, authToken, cluster)
 			if stepErr != nil {
-				c.logClusterErrorFiltered(ctx, cluster.ClusterUUID, constants.ErrApplicationCredentialDeleteFailed, "cluster_deletion", stepErr)
 				return stepErr
 			}
 			cluster.DeleteState = constants.DeleteStateCredentials
@@ -2724,15 +2714,12 @@ func (c *clusterService) RunDestroyCluster(ctx context.Context, authToken string
 				return err
 			}
 			if err := c.CreateAuditLog(ctx, cluster.ClusterUUID, cluster.ClusterProjectUUID, "Cluster Destroyed"); err != nil {
-				c.logger.WithError(err).WithFields(logrus.Fields{
-					"clusterUUID": cluster.ClusterUUID,
-				}).Error("failed to create audit log")
-				c.logClusterErrorFiltered(ctx, cluster.ClusterUUID, constants.ErrAuditLogCreateFailed, "cluster_deletion", err)
+				logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to create audit log")
 			}
 			return nil
 
 		default:
-			return fmt.Errorf("unsupported delete_state: %s", cluster.DeleteState)
+			return fmt.Errorf("%w: unsupported delete_state: %s", ErrDestroyClusterPermanent, cluster.DeleteState)
 		}
 	}
 }
@@ -2741,23 +2728,17 @@ func (c *clusterService) deleteLoadBalancerWithRetries(ctx context.Context, auth
 	maxRetries := 10
 	waitSeconds := 3
 	var lastError error
+	entry := c.logger.WithField("clusterUUID", cluster.ClusterUUID)
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		time.Sleep(time.Duration(waitSeconds) * time.Second)
 		if err := c.deleteLoadBalancerComponents(ctx, authToken, cluster); err != nil {
 			lastError = err
-			c.logger.WithError(err).WithFields(logrus.Fields{
-				"clusterUUID": cluster.ClusterUUID,
-				"attempt":     attempt,
-			}).Error("failed to delete load balancer components")
-		} else {
-			return nil
+			logDeleteRetry(entry, err, attempt, maxRetries, "failed to delete load balancer components")
+			continue
 		}
+		return nil
 	}
-	if lastError != nil {
-		c.logClusterErrorFiltered(ctx, cluster.ClusterUUID, constants.ErrLoadBalancerDeleteFailed, "cluster_deletion", lastError)
-		return lastError
-	}
-	return nil
+	return lastError
 }
 
 func (c *clusterService) updateClusterDeleteState(ctx context.Context, cluster *model.Cluster) error {
@@ -2771,11 +2752,10 @@ func (c *clusterService) updateClusterDeleteState(ctx context.Context, cluster *
 
 	err := c.repository.Cluster().DeleteUpdateCluster(ctx, clModel, cluster.ClusterUUID)
 	if err != nil {
-		c.logger.WithError(err).WithFields(logrus.Fields{
+		logRetryableFailure(c.logger.WithFields(logrus.Fields{
 			"clusterUUID": cluster.ClusterUUID,
 			"deleteState": cluster.DeleteState,
-		}).Error("failed to update cluster delete state")
-		c.logClusterError(ctx, cluster.ClusterUUID, fmt.Sprintf("Failed to update cluster delete state: %v", err))
+		}), err, "failed to update cluster delete state")
 		return fmt.Errorf("persist cluster delete_state %q: %w", cluster.DeleteState, err)
 	}
 	return nil
@@ -2883,10 +2863,10 @@ func (c *clusterService) deleteOpenStackLoadBalancerWithWait(ctx context.Context
 		err := c.loadbalancerService.DeleteLoadbalancer(ctx, token, lbID)
 		if err == nil {
 			if werr := c.loadbalancerService.WaitForLoadBalancerDeleted(ctx, token, lbID); werr != nil {
-				c.logger.WithError(werr).WithFields(logrus.Fields{
+				logRetryableFailure(c.logger.WithFields(logrus.Fields{
 					"clusterUUID":      clusterUUID,
 					"loadbalancerUUID": lbID,
-				}).Error("failed to wait for load balancer deletion")
+				}), werr, "failed to wait for load balancer deletion")
 				return werr
 			}
 			if verr := c.verifyLoadBalancerDeletedThreePasses(ctx, token, clusterUUID, lbID); verr != nil {
@@ -2905,20 +2885,13 @@ func (c *clusterService) deleteOpenStackLoadBalancerWithWait(ctx context.Context
 			return nil
 		}
 
-		if attempt == maxRetries {
-			c.logger.WithError(err).WithFields(logrus.Fields{
-				"clusterUUID":      clusterUUID,
-				"loadbalancerUUID": lbID,
-				"attempt":          attempt,
-			}).Error("failed to delete load balancer after all retries")
-			return err
-		}
-
-		c.logger.WithFields(logrus.Fields{
+		logDeleteRetry(c.logger.WithFields(logrus.Fields{
 			"clusterUUID":      clusterUUID,
 			"loadbalancerUUID": lbID,
-			"attempt":          attempt,
-		}).Warn("retrying load balancer deletion")
+		}), err, attempt, maxRetries, "retrying load balancer deletion")
+		if attempt == maxRetries {
+			return err
+		}
 
 		time.Sleep(time.Duration(attempt) * 5 * time.Second)
 	}
@@ -2956,10 +2929,10 @@ func (c *clusterService) deleteSingleLoadBalancer(ctx context.Context, authToken
 			}).Info("load balancer not found when listing pools; attempting direct delete")
 			skipChildResources = true
 		} else {
-			c.logger.WithError(err).WithFields(logrus.Fields{
+			logRetryableFailure(c.logger.WithFields(logrus.Fields{
 				"clusterUUID":      clusterUUID,
 				"loadbalancerUUID": lbID,
-			}).Error("failed to get load balancer pools")
+			}), err, "failed to get load balancer pools")
 			return err
 		}
 	}
@@ -2968,10 +2941,10 @@ func (c *clusterService) deleteSingleLoadBalancer(ctx context.Context, authToken
 		for _, pool := range pools.Pools {
 			err = c.loadbalancerService.DeleteLoadbalancerPools(ctx, token, pool)
 			if err != nil {
-				c.logger.WithError(err).WithFields(logrus.Fields{
+				logRetryableFailure(c.logger.WithFields(logrus.Fields{
 					"clusterUUID": clusterUUID,
 					"poolID":      pool,
-				}).Error("failed to delete pool")
+				}), err, "failed to delete pool")
 				return err
 			}
 		}
@@ -2979,10 +2952,10 @@ func (c *clusterService) deleteSingleLoadBalancer(ctx context.Context, authToken
 		listeners, lerr := c.loadbalancerService.GetLoadBalancerListeners(ctx, token, lbID)
 		if lerr != nil {
 			if !strings.Contains(lerr.Error(), "404") {
-				c.logger.WithError(lerr).WithFields(logrus.Fields{
+				logRetryableFailure(c.logger.WithFields(logrus.Fields{
 					"clusterUUID":      clusterUUID,
 					"loadbalancerUUID": lbID,
-				}).Error("failed to get load balancer listeners")
+				}), lerr, "failed to get load balancer listeners")
 				return lerr
 			}
 			c.logger.WithFields(logrus.Fields{
@@ -2995,18 +2968,18 @@ func (c *clusterService) deleteSingleLoadBalancer(ctx context.Context, authToken
 		for _, listener := range listeners.Listeners {
 			err = c.loadbalancerService.DeleteLoadbalancerListeners(ctx, token, listener)
 			if err != nil {
-				c.logger.WithError(err).WithFields(logrus.Fields{
+				logRetryableFailure(c.logger.WithFields(logrus.Fields{
 					"clusterUUID": clusterUUID,
 					"listenerID":  listener,
-				}).Error("failed to delete listener")
+				}), err, "failed to delete listener")
 				return err
 			}
 			err = c.loadbalancerService.CheckLoadBalancerDeletingListeners(ctx, token, listener)
 			if err != nil {
-				c.logger.WithError(err).WithFields(logrus.Fields{
+				logRetryableFailure(c.logger.WithFields(logrus.Fields{
 					"clusterUUID": clusterUUID,
 					"listenerID":  listener,
-				}).Error("failed to check listener deletion status")
+				}), err, "failed to check listener deletion status")
 				return err
 			}
 		}
@@ -3023,9 +2996,7 @@ func (c *clusterService) deleteLoadBalancerComponents(ctx context.Context, authT
 	for round := 1; round <= maxSweepRounds; round++ {
 		lbIDs, err := c.collectLoadBalancerIDsForDeletion(ctx, authToken, cluster)
 		if err != nil {
-			c.logger.WithError(err).WithFields(logrus.Fields{
-				"clusterUUID": cluster.ClusterUUID,
-			}).Error("failed to resolve load balancer ids for deletion")
+			logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to resolve load balancer ids for deletion")
 			return err
 		}
 		if len(lbIDs) == 0 {
@@ -3081,20 +3052,13 @@ func (c *clusterService) deleteDNSRecord(ctx context.Context, cluster *model.Clu
 			return nil
 		}
 
-		if attempt == maxRetries {
-			c.logger.WithError(err).WithFields(logrus.Fields{
-				"clusterUUID": cluster.ClusterUUID,
-				"recordID":    cluster.ClusterCloudflareRecordID,
-				"attempt":     attempt,
-			}).Error("failed to delete DNS record after all retries")
-			return err
-		}
-
-		c.logger.WithFields(logrus.Fields{
+		logDeleteRetry(c.logger.WithFields(logrus.Fields{
 			"clusterUUID": cluster.ClusterUUID,
 			"recordID":    cluster.ClusterCloudflareRecordID,
-			"attempt":     attempt,
-		}).Warn("retrying DNS record deletion")
+		}), err, attempt, maxRetries, "retrying DNS record deletion")
+		if attempt == maxRetries {
+			return err
+		}
 
 		time.Sleep(time.Duration(attempt) * 5 * time.Second)
 	}
@@ -3107,9 +3071,7 @@ func (c *clusterService) deleteFloatingIP(ctx context.Context, authToken string,
 
 	getFloatingIP, err := c.repository.Resources().GetResourceByClusterUUID(ctx, cluster.ClusterUUID, "floating_ip")
 	if err != nil {
-		c.logger.WithError(err).WithFields(logrus.Fields{
-			"clusterUUID": cluster.ClusterUUID,
-		}).Error("failed to get floating IP")
+		logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to get floating IP")
 		return err
 	}
 
@@ -3131,20 +3093,13 @@ func (c *clusterService) deleteFloatingIP(ctx context.Context, authToken string,
 			return nil
 		}
 
-		if attempt == maxRetries {
-			c.logger.WithError(err).WithFields(logrus.Fields{
-				"clusterUUID":    cluster.ClusterUUID,
-				"floatingIPUUID": getFloatingIP[0].ResourceUUID,
-				"attempt":        attempt,
-			}).Error("failed to delete floating IP after all retries")
-			return err
-		}
-
-		c.logger.WithFields(logrus.Fields{
+		logDeleteRetry(c.logger.WithFields(logrus.Fields{
 			"clusterUUID":    cluster.ClusterUUID,
 			"floatingIPUUID": getFloatingIP[0].ResourceUUID,
-			"attempt":        attempt,
-		}).Warn("retrying floating IP deletion")
+		}), err, attempt, maxRetries, "retrying floating IP deletion")
+		if attempt == maxRetries {
+			return err
+		}
 
 		time.Sleep(time.Duration(attempt) * 5 * time.Second)
 	}
@@ -3169,16 +3124,12 @@ func (c *clusterService) deleteNodeGroups(ctx context.Context, authToken string,
 	token := strings.Clone(authToken)
 	nodeGroup, err := c.repository.NodeGroups().GetNodeGroupsByClusterUUID(ctx, cluster.ClusterUUID, "", constants.ActiveNodeGroupStatus)
 	if err != nil {
-		c.logger.WithError(err).WithFields(logrus.Fields{
-			"clusterUUID": cluster.ClusterUUID,
-		}).Error("failed to get node groups")
+		logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to get node groups")
 		return err
 	}
 	getNodeGroups, err := c.repository.Resources().GetResourceByClusterUUID(ctx, cluster.ClusterUUID, "server_group")
 	if err != nil {
-		c.logger.WithError(err).WithFields(logrus.Fields{
-			"clusterUUID": cluster.ClusterUUID,
-		}).Error("failed to get node groups")
+		logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to get node groups")
 		return err
 	}
 
@@ -3211,11 +3162,10 @@ func (c *clusterService) deleteNodeGroups(ctx context.Context, authToken string,
 						}).Info("server not found, skipping deletion")
 						continue
 					}
-					c.logger.WithError(err).WithFields(logrus.Fields{
+					logDeleteRetry(c.logger.WithFields(logrus.Fields{
 						"clusterUUID": cluster.ClusterUUID,
 						"serverID":    serverID,
-						"attempt":     attempt,
-					}).Error("failed to delete server")
+					}), err, attempt, maxRetries, "failed to delete server")
 					if attempt == maxRetries {
 						return err
 					}
@@ -3235,6 +3185,10 @@ func (c *clusterService) deleteNodeGroups(ctx context.Context, authToken string,
 					}).Info("server group not found, skipping deletion")
 					break
 				}
+				logDeleteRetry(c.logger.WithFields(logrus.Fields{
+					"clusterUUID":   cluster.ClusterUUID,
+					"nodeGroupUUID": nodeGroup.ResourceUUID,
+				}), err, attempt, maxRetries, "failed to delete server group")
 				if attempt == maxRetries {
 					return err
 				}
@@ -3251,9 +3205,7 @@ func (c *clusterService) deleteNodeGroups(ctx context.Context, authToken string,
 		nodeGroup.NodeGroupDeleteDate = time.Now()
 		err = c.repository.NodeGroups().UpdateNodeGroups(ctx, &nodeGroup)
 		if err != nil {
-			c.logger.WithError(err).WithFields(logrus.Fields{
-				"clusterUUID": cluster.ClusterUUID,
-			}).Error("failed to delete node group")
+			logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to mark node group deleted")
 		}
 	}
 	return nil
@@ -3269,9 +3221,7 @@ func (c *clusterService) deleteSecurityGroups(ctx context.Context, authToken str
 
 	getSecurityGroups, err := c.repository.Resources().GetResourceByClusterUUID(ctx, cluster.ClusterUUID, "security_group")
 	if err != nil {
-		c.logger.WithError(err).WithFields(logrus.Fields{
-			"clusterUUID": cluster.ClusterUUID,
-		}).Error("failed to get security groups")
+		logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to get security groups")
 		return err
 	}
 	for _, nodeGroup := range getSecurityGroups {
@@ -3289,9 +3239,7 @@ func (c *clusterService) deleteSecurityGroups(ctx context.Context, authToken str
 	for _, sgUUID := range sgUUIDs {
 		tempPorts, err := c.networkService.GetSecurityGroupPorts(ctx, token, sgUUID)
 		if err != nil {
-			c.logger.WithError(err).WithFields(logrus.Fields{
-				"clusterUUID": cluster.ClusterUUID,
-			}).Error("failed to get security group ports")
+			logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to get security group ports")
 			return err
 		}
 
@@ -3302,10 +3250,10 @@ func (c *clusterService) deleteSecurityGroups(ctx context.Context, authToken str
 		for _, portID := range port.Ports {
 			err = c.networkService.DeleteNetworkPort(ctx, token, portID)
 			if err != nil && !strings.Contains(err.Error(), "404") {
-				c.logger.WithError(err).WithFields(logrus.Fields{
+				logRetryableFailure(c.logger.WithFields(logrus.Fields{
 					"clusterUUID": cluster.ClusterUUID,
 					"portID":      portID,
-				}).Error("failed to delete port")
+				}), err, "failed to delete port")
 				return err
 			}
 		}
@@ -3335,11 +3283,10 @@ func (c *clusterService) deleteSecurityGroups(ctx context.Context, authToken str
 			}
 
 			lastErr = err
-			c.logger.WithError(err).WithFields(logrus.Fields{
+			logDeleteRetry(c.logger.WithFields(logrus.Fields{
 				"clusterUUID": cluster.ClusterUUID,
 				"sgUUID":      sgUUID,
-				"attempt":     attempt,
-			}).Error("failed to delete security group")
+			}), err, attempt, maxRetries, "failed to delete security group")
 		}
 
 		if successCount == len(sgUUIDs) {
@@ -3371,9 +3318,7 @@ func applicationCredentialNotFoundOnKeystone(err error) bool {
 func (c *clusterService) deleteApplicationCredentials(ctx context.Context, identityToken, callerJobAuthToken string, cluster *model.Cluster) error {
 	getApplicationCredential, err := c.repository.Resources().GetResourceByClusterUUID(ctx, cluster.ClusterUUID, "application_credential")
 	if err != nil {
-		c.logger.WithError(err).WithFields(logrus.Fields{
-			"clusterUUID": cluster.ClusterUUID,
-		}).Error("failed to get application credential")
+		logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), err, "failed to get application credential")
 		return err
 	}
 	if len(getApplicationCredential) == 0 {
@@ -3398,19 +3343,17 @@ func (c *clusterService) deleteApplicationCredentials(ctx context.Context, ident
 		}).Warn("caller token did not delete application credential; retrying with cluster identity token")
 	}
 
-	if err := tryDelete(strings.Clone(identityToken)); err == nil {
-		return nil
+	if delErr := tryDelete(strings.Clone(identityToken)); delErr != nil {
+		if applicationCredentialNotFoundOnKeystone(delErr) {
+			c.logger.WithFields(logrus.Fields{
+				"clusterUUID": cluster.ClusterUUID,
+			}).Info("application credential not found on Keystone; treating as deleted")
+			return nil
+		}
+		logRetryableFailure(c.logger.WithField("clusterUUID", cluster.ClusterUUID), delErr, "failed to delete application credential")
+		return delErr
 	}
-	if applicationCredentialNotFoundOnKeystone(err) {
-		c.logger.WithFields(logrus.Fields{
-			"clusterUUID": cluster.ClusterUUID,
-		}).Info("application credential not found on Keystone; treating as deleted")
-		return nil
-	}
-	c.logger.WithError(err).WithFields(logrus.Fields{
-		"clusterUUID": cluster.ClusterUUID,
-	}).Error("failed to delete application credential")
-	return err
+	return nil
 }
 
 func (c *clusterService) GetKubeConfig(ctx context.Context, authToken, clusterID string) (resource.GetKubeConfigResponse, error) {

--- a/internal/service/compute.go
+++ b/internal/service/compute.go
@@ -154,10 +154,6 @@ func (cs *computeService) DeleteServerGroup(ctx context.Context, authToken, clus
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		cs.logger.WithFields(logrus.Fields{
-			"status_code": resp.StatusCode,
-			"error_msg":   resp.Status,
-		}).Error("failed to delete server group")
 		return fmt.Errorf("failed to delete server group, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 	return nil
@@ -553,10 +549,7 @@ func (cs *computeService) GetServerGroup(ctx context.Context, authToken string, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		cs.logger.WithFields(logrus.Fields{
-			"status_code": resp.StatusCode,
-			"error_msg":   resp.Status,
-		}).Error("failed to get server group")
+		logHTTPStatusFailure(cs.logger.WithField("serverGroupID", serverGroupID), resp.StatusCode, resp.Status, "failed to get server group")
 		return resource.GetServerGroupResponse{}, fmt.Errorf("failed to get server group, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 	var respData resource.GetServerGroupResponse
@@ -572,9 +565,7 @@ func (cs *computeService) DeleteServer(ctx context.Context, authToken string, se
 	token := strings.Clone(authToken)
 	volumes, err := cs.GetServerVolumes(ctx, token, serverID)
 	if err != nil && !strings.Contains(err.Error(), "404") {
-		cs.logger.WithError(err).WithFields(logrus.Fields{
-			"serverID": serverID,
-		}).Error("failed to get volumes")
+		logRetryableFailure(cs.logger.WithField("serverID", serverID), err, "failed to get volumes")
 		return err
 	}
 
@@ -594,20 +585,17 @@ func (cs *computeService) DeleteServer(ctx context.Context, authToken string, se
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		cs.logger.WithFields(logrus.Fields{
-			"status_code": resp.StatusCode,
-			"error_msg":   resp.Status,
-		}).Error("failed to delete server")
+		logHTTPStatusFailure(cs.logger.WithField("serverID", serverID), resp.StatusCode, resp.Status, "failed to delete server")
 		return fmt.Errorf("failed to delete server, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 
 	for _, volumeID := range volumes {
 		err = cs.DeleteVolume(ctx, authToken, volumeID)
 		if err != nil && !strings.Contains(err.Error(), "404") {
-			cs.logger.WithError(err).WithFields(logrus.Fields{
+			logRetryableFailure(cs.logger.WithFields(logrus.Fields{
 				"serverID": serverID,
 				"volumeID": volumeID,
-			}).Error("failed to delete volume")
+			}), err, "failed to delete volume")
 			return err
 		}
 	}

--- a/internal/service/delete_log.go
+++ b/internal/service/delete_log.go
@@ -31,7 +31,7 @@ func logDeleteRetry(entry *logrus.Entry, err error, attempt, maxAttempts int, ms
 	if err != nil {
 		e = e.WithError(err)
 	}
-	e.Warn(msg)
+	e.Info(msg)
 }
 
 func logRetryableFailure(entry *logrus.Entry, err error, msg string) {
@@ -42,7 +42,7 @@ func logRetryableFailure(entry *logrus.Entry, err error, msg string) {
 	if err != nil {
 		e = e.WithError(err)
 	}
-	e.Warn(msg)
+	e.Info(msg)
 }
 
 func isRetryableHTTPStatus(code int) bool {
@@ -67,7 +67,7 @@ func logHTTPStatusFailure(entry *logrus.Entry, statusCode int, status, msg strin
 		"retryable":  isRetryableHTTPStatus(statusCode),
 	})
 	if isRetryableHTTPStatus(statusCode) {
-		entry.Warn(msg)
+		entry.Info(msg)
 		return
 	}
 	entry.Error(msg)

--- a/internal/service/delete_log.go
+++ b/internal/service/delete_log.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	deleteOutcomeRetrying              = "retrying"
+	deleteOutcomeInnerRetriesExhausted = "inner_retries_exhausted"
+)
+
+func deleteRetryFields(attempt, maxAttempts int) logrus.Fields {
+	innerRetry := attempt < maxAttempts
+	outcome := deleteOutcomeRetrying
+	if !innerRetry {
+		outcome = deleteOutcomeInnerRetriesExhausted
+	}
+	return logrus.Fields{
+		"attempt":     attempt,
+		"maxAttempts": maxAttempts,
+		"willRetry":   innerRetry,
+		"retryable":   true,
+		"outcome":     outcome,
+	}
+}
+
+func logDeleteRetry(entry *logrus.Entry, err error, attempt, maxAttempts int, msg string) {
+	e := entry.WithFields(deleteRetryFields(attempt, maxAttempts))
+	if err != nil {
+		e = e.WithError(err)
+	}
+	e.Warn(msg)
+}
+
+func logRetryableFailure(entry *logrus.Entry, err error, msg string) {
+	e := entry.WithFields(logrus.Fields{
+		"retryable": true,
+		"outcome":   deleteOutcomeRetrying,
+	})
+	if err != nil {
+		e = e.WithError(err)
+	}
+	e.Warn(msg)
+}
+
+func isRetryableHTTPStatus(code int) bool {
+	switch code {
+	case http.StatusNotFound,
+		http.StatusConflict,
+		http.StatusTooManyRequests,
+		http.StatusRequestTimeout,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout:
+		return true
+	default:
+		return code >= 500
+	}
+}
+
+func logHTTPStatusFailure(entry *logrus.Entry, statusCode int, status, msg string) {
+	entry = entry.WithFields(logrus.Fields{
+		"statusCode": statusCode,
+		"status":     status,
+		"retryable":  isRetryableHTTPStatus(statusCode),
+	})
+	if isRetryableHTTPStatus(statusCode) {
+		entry.Warn(msg)
+		return
+	}
+	entry.Error(msg)
+}

--- a/internal/service/delete_log_test.go
+++ b/internal/service/delete_log_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRetryableHTTPStatus(t *testing.T) {
+	t.Parallel()
+
+	retryable := []int{
+		http.StatusNotFound,
+		http.StatusConflict,
+		http.StatusTooManyRequests,
+		http.StatusRequestTimeout,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		http.StatusInternalServerError,
+	}
+	for _, code := range retryable {
+		assert.True(t, isRetryableHTTPStatus(code), "status=%d", code)
+	}
+
+	permanent := []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusBadRequest}
+	for _, code := range permanent {
+		assert.False(t, isRetryableHTTPStatus(code), "status=%d", code)
+	}
+}
+
+func TestDeleteRetryFields(t *testing.T) {
+	t.Parallel()
+
+	mid := deleteRetryFields(3, 10)
+	assert.Equal(t, 3, mid["attempt"])
+	assert.Equal(t, 10, mid["maxAttempts"])
+	assert.Equal(t, true, mid["willRetry"])
+	assert.Equal(t, true, mid["retryable"])
+	assert.Equal(t, deleteOutcomeRetrying, mid["outcome"])
+
+	last := deleteRetryFields(10, 10)
+	assert.Equal(t, false, last["willRetry"])
+	assert.Equal(t, true, last["retryable"])
+	assert.Equal(t, deleteOutcomeInnerRetriesExhausted, last["outcome"])
+}
+
+func TestErrDestroyClusterPermanentWrap(t *testing.T) {
+	t.Parallel()
+
+	inner := fmt.Errorf("decrypt failed")
+	err := fmt.Errorf("%w: decrypt application credential: %w", ErrDestroyClusterPermanent, inner)
+	assert.True(t, errors.Is(err, ErrDestroyClusterPermanent))
+	assert.True(t, errors.Is(err, inner))
+}
+
+func TestLogHTTPStatusFailureDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	entry := logrus.NewEntry(logger)
+	logHTTPStatusFailure(entry, http.StatusConflict, "409 Conflict", "failed to delete load balancer")
+	logHTTPStatusFailure(entry, http.StatusUnauthorized, "401 Unauthorized", "failed to delete load balancer")
+	logRetryableFailure(entry, fmt.Errorf("transient"), "failed to get cluster")
+}

--- a/internal/service/identity.go
+++ b/internal/service/identity.go
@@ -174,7 +174,7 @@ func (i *identityService) DeleteApplicationCredential(ctx context.Context, authT
 	token := strings.Clone(authToken)
 	getUserID, err := i.GetTokenDetail(ctx, token)
 	if err != nil {
-		i.logger.WithError(err).Error("failed to get user id")
+		logRetryableFailure(i.logger.WithField("applicationCredentialID", applicationCredentialID), err, "failed to get user id")
 		return err
 	}
 	applicationCredentialPath := fmt.Sprintf("v3/users/%s/application_credentials/%v", getUserID, applicationCredentialID)

--- a/internal/service/loadbalancer.go
+++ b/internal/service/loadbalancer.go
@@ -913,10 +913,7 @@ func (lbc *loadbalancerService) DeleteLoadbalancerPools(ctx context.Context, aut
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		lbc.withLog(ctx).WithFields(logrus.Fields{
-			"statusCode": resp.StatusCode,
-			"status":     resp.Status,
-		}).Error("failed to delete load balancer pool")
+		logHTTPStatusFailure(lbc.withLog(ctx), resp.StatusCode, resp.Status, "failed to delete load balancer pool")
 		return fmt.Errorf("failed to delete load balancer pool, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 	return nil
@@ -1051,10 +1048,7 @@ func (lbc *loadbalancerService) DeleteLoadbalancerListeners(ctx context.Context,
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		lbc.withLog(ctx).WithFields(logrus.Fields{
-			"statusCode": resp.StatusCode,
-			"status":     resp.Status,
-		}).Error("failed to delete load balancer listener")
+		logHTTPStatusFailure(lbc.withLog(ctx), resp.StatusCode, resp.Status, "failed to delete load balancer listener")
 		return fmt.Errorf("failed to delete load balancer listener, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 	return nil
@@ -1131,11 +1125,7 @@ func (lbc *loadbalancerService) DeleteLoadbalancer(ctx context.Context, authToke
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		lbc.withLog(ctx).WithFields(logrus.Fields{
-			"loadBalancerID": loadBalancerID,
-			"statusCode":     resp.StatusCode,
-			"status":         resp.Status,
-		}).Error("failed to delete load balancer")
+		logHTTPStatusFailure(lbc.withLog(ctx).WithField("loadBalancerID", loadBalancerID), resp.StatusCode, resp.Status, "failed to delete load balancer")
 		return fmt.Errorf("failed to delete load balancer, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 

--- a/internal/service/mocks/service_mock.go
+++ b/internal/service/mocks/service_mock.go
@@ -1217,6 +1217,20 @@ func (mr *MockICloudflareServiceMockRecorder) DeleteDNSRecordFromCloudflare(ctx,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDNSRecordFromCloudflare", reflect.TypeOf((*MockICloudflareService)(nil).DeleteDNSRecordFromCloudflare), ctx, dnsRecordID)
 }
 
+// UpdateDNSRecordContent mocks base method.
+func (m *MockICloudflareService) UpdateDNSRecordContent(ctx context.Context, recordID, ip string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDNSRecordContent", ctx, recordID, ip)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDNSRecordContent indicates an expected call of UpdateDNSRecordContent.
+func (mr *MockICloudflareServiceMockRecorder) UpdateDNSRecordContent(ctx, recordID, ip any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDNSRecordContent", reflect.TypeOf((*MockICloudflareService)(nil).UpdateDNSRecordContent), ctx, recordID, ip)
+}
+
 // MockIIdentityService is a mock of IIdentityService interface.
 type MockIIdentityService struct {
 	ctrl     *gomock.Controller

--- a/internal/service/network.go
+++ b/internal/service/network.go
@@ -641,10 +641,6 @@ func (ns *networkService) DeleteNetworkPort(ctx context.Context, authToken strin
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		ns.logger.WithFields(logrus.Fields{
-			"status_code": resp.StatusCode,
-			"error_msg":   resp.Status,
-		}).Error("failed to delete network port")
 		return fmt.Errorf("failed to delete network port, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 
@@ -670,10 +666,7 @@ func (ns *networkService) GetSecurityGroupPorts(ctx context.Context, authToken, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		ns.logger.WithFields(logrus.Fields{
-			"status_code": resp.StatusCode,
-			"error_msg":   resp.Status,
-		}).Error("failed to list ports")
+		logHTTPStatusFailure(ns.logger.WithField("securityGroupID", securityGroupID), resp.StatusCode, resp.Status, "failed to list ports")
 		return resource.NetworkPortsResponse{}, fmt.Errorf("failed to list ports, status code: %v, error msg: %v", resp.StatusCode, resp.Status)
 	}
 

--- a/pkg/constants/error.go
+++ b/pkg/constants/error.go
@@ -21,6 +21,7 @@ const (
 	ErrClusterSubnetInvalid  = "Invalid subnet configuration"
 	ErrClusterKeypairInvalid = "Invalid node keypair name"
 	ErrClusterGetFailed      = "Failed to get cluster"
+	ErrClusterDeleteFailed   = "Cluster deletion failed permanently"
 
 	// Cluster Resource Errors
 	ErrLoadBalancerCreateFailed          = "Failed to create load balancer for cluster"


### PR DESCRIPTION
Cluster deletion may temporarily fail while dependent resources are still
being removed. These failures are retried by the delete job and do not
necessarily indicate that the cluster deletion has failed.

Change the log level for retryable cluster delete failures from error to
warning. Keep retry attempts visible in the logs without reporting them as
errors while the operation can still recover.

Log an error only when all retry attempts are exhausted and the cluster
delete job fails permanently.